### PR TITLE
Add GPU monitoring support (NVIDIA & AMD)

### DIFF
--- a/pc_stats_monitor_v2.py
+++ b/pc_stats_monitor_v2.py
@@ -59,6 +59,7 @@ sensor_database = {
     "power": [],
     "data": [],       # Network/disk data (uploaded/downloaded GB)
     "throughput": [], # Network throughput (upload/download speed KB/s, MB/s)
+    "gpu": [],        # GPU metrics (usage, memory, freq, fan, power) — from LHM
     "other": []
 }
 
@@ -431,8 +432,10 @@ def discover_sensors_via_http(host, port):
                     "parent_hardware": parent_hardware  # Hardware name (useful for NICs)
                 }
 
-                # Categorize sensor
-                if sensor_type == "temperature":
+                # Categorize sensor — GPU sensors go to dedicated "gpu" category
+                if _is_gpu_sensor(sensor_id):
+                    sensor_database["gpu"].append(sensor_info)
+                elif sensor_type == "temperature":
                     sensor_database["temperature"].append(sensor_info)
                 elif sensor_type == "fan":
                     sensor_database["fan"].append(sensor_info)
@@ -455,6 +458,7 @@ def discover_sensors_via_http(host, port):
 
             if sensor_count > 0:
                 print(f"  ✓ Found {sensor_count} hardware sensors via REST API:")
+                print(f"    - GPU:         {len(sensor_database['gpu'])}")
                 print(f"    - Temperatures: {len(sensor_database['temperature'])}")
                 print(f"    - Fans: {len(sensor_database['fan'])}")
                 print(f"    - Loads: {len(sensor_database['load'])}")
@@ -842,6 +846,22 @@ def generate_short_name_from_id(sensor_id, sensor_type, sensor_name=""):
         return _make_unique_name(f"{device}{sensor_idx}")
 
 
+def _is_gpu_sensor(identifier):
+    """
+    Return True if the LHM sensor identifier belongs to a GPU device.
+    Uses the same device-part logic as generate_short_name_from_id so that
+    AMD CPU sensors (amdcpu) are NOT mistaken for GPU sensors.
+    """
+    parts = identifier.lower().split('/')
+    if len(parts) < 2:
+        return False
+    device = parts[1]
+    # "cpu" check must come first to exclude intelcpu / amdcpu
+    if "cpu" in device:
+        return False
+    return "gpu" in device or "nvidia" in device or "amd" in device
+
+
 def check_wmi_connectivity():
     """
     Diagnostics: Check if LibreHardwareMonitor WMI namespace is accessible
@@ -1202,8 +1222,11 @@ def discover_sensors():
                 "is_active_nic": is_active_nic
             }
 
-            # Categorize sensor
-            if sensor_type_lower == "temperature":
+            # Categorize sensor — GPU sensors go to dedicated "gpu" category
+            if _is_gpu_sensor(sensor.Identifier):
+                sensor_database["gpu"].append(sensor_info)
+                sensor_count += 1
+            elif sensor_type_lower == "temperature":
                 sensor_database["temperature"].append(sensor_info)
                 sensor_count += 1
             elif sensor_type_lower == "fan":
@@ -1229,6 +1252,7 @@ def discover_sensors():
                 sensor_count += 1
 
         print(f"  Found {sensor_count} hardware sensors:")
+        print(f"    - GPU:          {len(sensor_database['gpu'])}")
         print(f"    - Temperatures: {len(sensor_database['temperature'])}")
         print(f"    - Fans: {len(sensor_database['fan'])}")
         print(f"    - Loads: {len(sensor_database['load'])}")
@@ -1703,6 +1727,7 @@ class MetricSelectorGUI:
         # Create checkboxes by category
         categories = [
             ("SYSTEM METRICS", "system"),
+            ("GPU METRICS", "gpu"),
             ("TEMPERATURES", "temperature"),
             ("FANS & COOLING", "fan"),
             ("LOADS", "load"),

--- a/pc_stats_monitor_v2_linux.py
+++ b/pc_stats_monitor_v2_linux.py
@@ -10,6 +10,7 @@ import time
 import json
 import os
 import sys
+import glob as _glob
 import argparse
 from datetime import datetime
 
@@ -38,12 +39,16 @@ sensor_database = {
     "fan": [],         # Fan speeds
     "data": [],        # Network data (total uploaded/downloaded)
     "throughput": [],  # Network throughput (current upload/download speed)
+    "gpu": [],         # GPU metrics (usage, memory, freq, fan, power)
     "other": []
 }
 
 # Network tracking for speed calculation
 network_last_sample = {}
 network_last_time = None
+
+# NVML handles for NVIDIA GPU (populated during sensor discovery or lazily)
+nvml_handles = {}
 
 
 def discover_sensors():
@@ -185,7 +190,7 @@ def discover_sensors():
         print(f"  WARNING: Could not access hardware sensors: {e}")
 
     # Discover network metrics
-    print("\n[3/3] Discovering network metrics...")
+    print("\n[3/4] Discovering network metrics...")
     net_count = 0
 
     try:
@@ -257,6 +262,20 @@ def discover_sensors():
     except Exception as e:
         print(f"  WARNING: Could not access network stats: {e}")
 
+    # Discover GPU metrics
+    print("\n[4/4] Discovering GPU sensors...")
+    nvidia_found = _discover_nvidia_sensors()
+    if not nvidia_found:
+        _discover_amd_sensors()
+
+    total_gpu = len(sensor_database["gpu"])
+    if total_gpu:
+        print(f"  Found {total_gpu} GPU metric(s)")
+    else:
+        print("  No GPU sensors found")
+        print("  NVIDIA: pip install nvidia-ml-py3")
+        print("  AMD:    requires amdgpu kernel driver (/sys/class/drm/)")
+
     print("\n" + "=" * 60)
     print("\nℹ NOTE: Sensor values in GUI are static (captured at launch time)")
     print("  This helps you identify active sensors and their typical readings.")
@@ -312,6 +331,264 @@ def generate_short_name_linux(label, sensor_type, sensor_key=""):
         name = name[:10]
 
     return name if name else "SENSOR"
+
+
+# ============================================================================
+# GPU Sensor Discovery
+# ============================================================================
+
+def _discover_nvidia_sensors():
+    """
+    Discover NVIDIA GPU sensors via pynvml (nvidia-ml-py3).
+    Populates sensor_database["gpu"] and nvml_handles.
+    Returns True if any GPU was found.
+    """
+    global nvml_handles
+    try:
+        import pynvml
+        pynvml.nvmlInit()
+        device_count = pynvml.nvmlDeviceGetCount()
+
+        for i in range(device_count):
+            handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+            nvml_handles[i] = handle
+
+            try:
+                gpu_name = pynvml.nvmlDeviceGetName(handle)
+                if isinstance(gpu_name, bytes):
+                    gpu_name = gpu_name.decode("utf-8")
+            except Exception:
+                gpu_name = f"NVIDIA GPU {i}"
+
+            prefix = f"GPU{i}" if device_count > 1 else "GPU"
+
+            # GPU Usage %
+            try:
+                util_val = pynvml.nvmlDeviceGetUtilizationRates(handle).gpu
+            except Exception:
+                util_val = 0
+            sensor_database["gpu"].append({
+                "name": f"{prefix}_USE",
+                "display_name": f"GPU Usage [{gpu_name}]",
+                "source": "nvml_gpu",
+                "type": "percent",
+                "unit": "%",
+                "gpu_index": i,
+                "metric": "utilization",
+                "custom_label": "",
+                "current_value": util_val
+            })
+
+            # GPU Memory Used (MB)
+            try:
+                mem_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                mem_val = int(mem_info.used / (1024 ** 2))
+            except Exception:
+                mem_val = 0
+            sensor_database["gpu"].append({
+                "name": f"{prefix}_MEM",
+                "display_name": f"GPU Memory [{gpu_name}]",
+                "source": "nvml_gpu",
+                "type": "memory",
+                "unit": "MB",
+                "gpu_index": i,
+                "metric": "memory_used",
+                "custom_label": "",
+                "current_value": mem_val
+            })
+
+            # GPU Core Frequency (MHz)
+            try:
+                freq_val = pynvml.nvmlDeviceGetClockInfo(handle, pynvml.NVML_CLOCK_GRAPHICS)
+            except Exception:
+                freq_val = 0
+            sensor_database["gpu"].append({
+                "name": f"{prefix}_FRQ",
+                "display_name": f"GPU Freq [{gpu_name}]",
+                "source": "nvml_gpu",
+                "type": "frequency",
+                "unit": "MHz",
+                "gpu_index": i,
+                "metric": "clock_graphics",
+                "custom_label": "",
+                "current_value": freq_val
+            })
+
+            # GPU Fan Speed (%)
+            try:
+                fan_val = pynvml.nvmlDeviceGetFanSpeed(handle)
+            except Exception:
+                fan_val = 0
+            sensor_database["gpu"].append({
+                "name": f"{prefix}_FAN",
+                "display_name": f"GPU Fan [{gpu_name}]",
+                "source": "nvml_gpu",
+                "type": "percent",
+                "unit": "%",
+                "gpu_index": i,
+                "metric": "fan_speed",
+                "custom_label": "",
+                "current_value": fan_val
+            })
+
+            # GPU Power (W)
+            try:
+                power_val = int(pynvml.nvmlDeviceGetPowerUsage(handle) / 1000)
+            except Exception:
+                power_val = 0
+            sensor_database["gpu"].append({
+                "name": f"{prefix}_PWR",
+                "display_name": f"GPU Power [{gpu_name}]",
+                "source": "nvml_gpu",
+                "type": "power",
+                "unit": "W",
+                "gpu_index": i,
+                "metric": "power_usage",
+                "custom_label": "",
+                "current_value": power_val
+            })
+
+        if device_count > 0:
+            print(f"  NVIDIA: {device_count} GPU(s) detected via pynvml")
+            return True
+        return False
+
+    except ImportError:
+        print("  NVIDIA: pynvml not installed (pip install nvidia-ml-py3)")
+    except Exception as e:
+        print(f"  NVIDIA: {e}")
+
+    return False
+
+
+def _discover_amd_sensors():
+    """
+    Discover AMD GPU sensors via Linux sysfs (/sys/class/drm/).
+    Populates sensor_database["gpu"].
+    Returns True if any GPU was found.
+    """
+    AMD_VENDOR_ID = "0x1002"
+    drm_cards = sorted(_glob.glob("/sys/class/drm/card[0-9]"))
+    found = False
+
+    def _read_int(path):
+        try:
+            with open(path) as f:
+                return int(f.read().strip())
+        except OSError:
+            return None
+
+    for card_path in drm_cards:
+        device_path = os.path.join(card_path, "device")
+        try:
+            with open(os.path.join(device_path, "vendor")) as f:
+                if f.read().strip().lower() != AMD_VENDOR_ID:
+                    continue
+        except OSError:
+            continue
+
+        card_name = os.path.basename(card_path)          # e.g. "card0"
+        gpu_name  = f"AMD GPU ({card_name})"
+        prefix    = card_name.upper()                     # e.g. "CARD0"
+
+        hwmon_dirs = sorted(_glob.glob(os.path.join(device_path, "hwmon", "hwmon*")))
+        hwmon_path = hwmon_dirs[0] if hwmon_dirs else None
+
+        # GPU Usage %
+        busy_val = _read_int(os.path.join(device_path, "gpu_busy_percent"))
+        if busy_val is not None:
+            sensor_database["gpu"].append({
+                "name": f"{prefix}_USE",
+                "display_name": f"GPU Usage [{gpu_name}]",
+                "source": "amd_sysfs",
+                "type": "percent",
+                "unit": "%",
+                "device_path": device_path,
+                "hwmon_path": hwmon_path,
+                "metric": "gpu_busy_percent",
+                "custom_label": "",
+                "current_value": busy_val
+            })
+            found = True
+
+        # GPU Memory Used (MB)
+        vram_val = _read_int(os.path.join(device_path, "mem_info_vram_used"))
+        if vram_val is not None:
+            sensor_database["gpu"].append({
+                "name": f"{prefix}_MEM",
+                "display_name": f"GPU Memory [{gpu_name}]",
+                "source": "amd_sysfs",
+                "type": "memory",
+                "unit": "MB",
+                "device_path": device_path,
+                "hwmon_path": hwmon_path,
+                "metric": "mem_info_vram_used",
+                "custom_label": "",
+                "current_value": int(vram_val / (1024 ** 2))
+            })
+            found = True
+
+        if hwmon_path:
+            # GPU Core Frequency (Hz → MHz)
+            freq_val = _read_int(os.path.join(hwmon_path, "freq1_input"))
+            if freq_val is not None:
+                sensor_database["gpu"].append({
+                    "name": f"{prefix}_FRQ",
+                    "display_name": f"GPU Freq [{gpu_name}]",
+                    "source": "amd_sysfs",
+                    "type": "frequency",
+                    "unit": "MHz",
+                    "device_path": device_path,
+                    "hwmon_path": hwmon_path,
+                    "metric": "freq1_input",
+                    "custom_label": "",
+                    "current_value": freq_val // 1_000_000
+                })
+                found = True
+
+            # Fan Speed (RPM)
+            fan_val = _read_int(os.path.join(hwmon_path, "fan1_input"))
+            if fan_val is not None:
+                sensor_database["gpu"].append({
+                    "name": f"{prefix}_FAN",
+                    "display_name": f"GPU Fan [{gpu_name}]",
+                    "source": "amd_sysfs",
+                    "type": "fan",
+                    "unit": "RPM",
+                    "device_path": device_path,
+                    "hwmon_path": hwmon_path,
+                    "metric": "fan1_input",
+                    "custom_label": "",
+                    "current_value": fan_val
+                })
+                found = True
+
+            # Power (µW → W); prefer power1_average, fall back to power1_input
+            for pwr_metric in ("power1_average", "power1_input"):
+                pwr_val = _read_int(os.path.join(hwmon_path, pwr_metric))
+                if pwr_val is not None:
+                    sensor_database["gpu"].append({
+                        "name": f"{prefix}_PWR",
+                        "display_name": f"GPU Power [{gpu_name}]",
+                        "source": "amd_sysfs",
+                        "type": "power",
+                        "unit": "W",
+                        "device_path": device_path,
+                        "hwmon_path": hwmon_path,
+                        "metric": pwr_metric,
+                        "custom_label": "",
+                        "current_value": int(pwr_val / 1_000_000)
+                    })
+                    found = True
+                    break
+
+    if found:
+        amd_count = sum(1 for s in sensor_database["gpu"] if s["source"] == "amd_sysfs")
+        print(f"  AMD: {amd_count} metric(s) detected via sysfs")
+    else:
+        print("  AMD: no GPU found (requires amdgpu kernel driver)")
+
+    return found
 
 
 # ============================================================================
@@ -755,7 +1032,8 @@ class MetricSelectorGUI:
             ("TEMPERATURES", "temperature"),
             ("FANS & COOLING", "fan"),
             ("NETWORK DATA", "data"),
-            ("NETWORK THROUGHPUT", "throughput")
+            ("NETWORK THROUGHPUT", "throughput"),
+            ("GPU METRICS", "gpu")
         ]
 
         for cat_title, cat_key in categories:
@@ -1057,7 +1335,8 @@ def display_all_sensors_cli():
         ("TEMPERATURES", "temperature"),
         ("FANS & COOLING", "fan"),
         ("NETWORK DATA", "data"),
-        ("NETWORK THROUGHPUT", "throughput")
+        ("NETWORK THROUGHPUT", "throughput"),
+        ("GPU METRICS", "gpu")
     ]
 
     for cat_title, cat_key in categories:
@@ -1422,6 +1701,55 @@ def get_metric_value(metric_config):
 
                 return 0
         except:
+            pass
+
+    elif source == "nvml_gpu":
+        try:
+            import pynvml
+            gpu_index = metric_config["gpu_index"]
+            # Lazy-init: works even when monitoring starts from a saved config
+            if gpu_index not in nvml_handles:
+                if not nvml_handles:
+                    pynvml.nvmlInit()
+                nvml_handles[gpu_index] = pynvml.nvmlDeviceGetHandleByIndex(gpu_index)
+            handle = nvml_handles[gpu_index]
+            metric = metric_config["metric"]
+
+            if metric == "utilization":
+                return pynvml.nvmlDeviceGetUtilizationRates(handle).gpu
+            elif metric == "memory_used":
+                return int(pynvml.nvmlDeviceGetMemoryInfo(handle).used / (1024 ** 2))
+            elif metric == "clock_graphics":
+                return pynvml.nvmlDeviceGetClockInfo(handle, pynvml.NVML_CLOCK_GRAPHICS)
+            elif metric == "fan_speed":
+                return pynvml.nvmlDeviceGetFanSpeed(handle)
+            elif metric == "power_usage":
+                return int(pynvml.nvmlDeviceGetPowerUsage(handle) / 1000)
+        except Exception:
+            pass
+
+    elif source == "amd_sysfs":
+        try:
+            metric      = metric_config["metric"]
+            device_path = metric_config["device_path"]
+            hwmon_path  = metric_config.get("hwmon_path")
+
+            if metric == "gpu_busy_percent":
+                with open(os.path.join(device_path, metric)) as f:
+                    return int(f.read().strip())
+            elif metric == "mem_info_vram_used":
+                with open(os.path.join(device_path, metric)) as f:
+                    return int(int(f.read().strip()) / (1024 ** 2))
+            elif metric == "freq1_input":
+                with open(os.path.join(hwmon_path, metric)) as f:
+                    return int(f.read().strip()) // 1_000_000
+            elif metric == "fan1_input":
+                with open(os.path.join(hwmon_path, metric)) as f:
+                    return int(f.read().strip())
+            elif metric in ("power1_average", "power1_input"):
+                with open(os.path.join(hwmon_path, metric)) as f:
+                    return int(int(f.read().strip()) / 1_000_000)
+        except Exception:
             pass
 
     return 0

--- a/pc_stats_monitor_v2_linux.py
+++ b/pc_stats_monitor_v2_linux.py
@@ -448,6 +448,41 @@ def _discover_nvidia_sensors():
                 "current_value": power_val
             })
 
+            # GPU Temperature (°C)
+            try:
+                temp_val = pynvml.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU)
+            except Exception:
+                temp_val = 0
+            sensor_database["gpu"].append({
+                "name": f"{prefix}_TMP",
+                "display_name": f"GPU Temp [{gpu_name}]",
+                "source": "nvml_gpu",
+                "type": "temperature",
+                "unit": "C",
+                "gpu_index": i,
+                "metric": "temperature",
+                "custom_label": "",
+                "current_value": temp_val
+            })
+
+            # GPU Memory Used %
+            try:
+                mem_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                mem_pct = int(mem_info.used * 100 / mem_info.total) if mem_info.total > 0 else 0
+            except Exception:
+                mem_pct = 0
+            sensor_database["gpu"].append({
+                "name": f"{prefix}_MEMP",
+                "display_name": f"GPU Mem % [{gpu_name}]",
+                "source": "nvml_gpu",
+                "type": "percent",
+                "unit": "%",
+                "gpu_index": i,
+                "metric": "memory_percent",
+                "custom_label": "",
+                "current_value": mem_pct
+            })
+
         if device_count > 0:
             print(f"  NVIDIA: {device_count} GPU(s) detected via pynvml")
             return True
@@ -528,7 +563,41 @@ def _discover_amd_sensors():
             })
             found = True
 
+        # GPU Memory Used %
+        vram_total_val = _read_int(os.path.join(device_path, "mem_info_vram_total"))
+        if vram_val is not None and vram_total_val is not None and vram_total_val > 0:
+            sensor_database["gpu"].append({
+                "name": f"{prefix}_MEMP",
+                "display_name": f"GPU Mem % [{gpu_name}]",
+                "source": "amd_sysfs",
+                "type": "percent",
+                "unit": "%",
+                "device_path": device_path,
+                "hwmon_path": hwmon_path,
+                "metric": "mem_percent",
+                "custom_label": "",
+                "current_value": int(vram_val * 100 / vram_total_val)
+            })
+            found = True
+
         if hwmon_path:
+            # GPU Temperature (millidegrees C → °C)
+            temp_val = _read_int(os.path.join(hwmon_path, "temp1_input"))
+            if temp_val is not None:
+                sensor_database["gpu"].append({
+                    "name": f"{prefix}_TMP",
+                    "display_name": f"GPU Temp [{gpu_name}]",
+                    "source": "amd_sysfs",
+                    "type": "temperature",
+                    "unit": "C",
+                    "device_path": device_path,
+                    "hwmon_path": hwmon_path,
+                    "metric": "temp1_input",
+                    "custom_label": "",
+                    "current_value": temp_val // 1000
+                })
+                found = True
+
             # GPU Core Frequency (Hz → MHz)
             freq_val = _read_int(os.path.join(hwmon_path, "freq1_input"))
             if freq_val is not None:
@@ -1719,12 +1788,17 @@ def get_metric_value(metric_config):
                 return pynvml.nvmlDeviceGetUtilizationRates(handle).gpu
             elif metric == "memory_used":
                 return int(pynvml.nvmlDeviceGetMemoryInfo(handle).used / (1024 ** 2))
+            elif metric == "memory_percent":
+                info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                return int(info.used * 100 / info.total) if info.total > 0 else 0
             elif metric == "clock_graphics":
                 return pynvml.nvmlDeviceGetClockInfo(handle, pynvml.NVML_CLOCK_GRAPHICS)
             elif metric == "fan_speed":
                 return pynvml.nvmlDeviceGetFanSpeed(handle)
             elif metric == "power_usage":
                 return int(pynvml.nvmlDeviceGetPowerUsage(handle) / 1000)
+            elif metric == "temperature":
+                return pynvml.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU)
         except Exception:
             pass
 
@@ -1749,6 +1823,13 @@ def get_metric_value(metric_config):
             elif metric in ("power1_average", "power1_input"):
                 with open(os.path.join(hwmon_path, metric)) as f:
                     return int(int(f.read().strip()) / 1_000_000)
+            elif metric == "temp1_input":
+                with open(os.path.join(hwmon_path, metric)) as f:
+                    return int(f.read().strip()) // 1000
+            elif metric == "mem_percent":
+                used  = int(open(os.path.join(device_path, "mem_info_vram_used")).read().strip())
+                total = int(open(os.path.join(device_path, "mem_info_vram_total")).read().strip())
+                return int(used * 100 / total) if total > 0 else 0
         except Exception:
             pass
 


### PR DESCRIPTION
- Added a dedicated `gpu` sensor category to both Windows (`pc_stats_monitor_v2.py`) and Linux (`pc_stats_monitor_v2_linux.py`) versions of the monitor.
- **NVIDIA**: discovery and live polling via `pynvml` (nvidia-ml-py3). Automatically initializes lazily — monitoring works even when started from a saved config without running discovery first.
- **AMD**: discovery and live polling via Linux sysfs (`/sys/class/drm/`), requires `amdgpu` kernel driver. Vendor is detected by reading `/device/vendor` (`0x1002`).

## Metrics collected per GPU

| Metric             | Unit    | Source                              |
|--------------------|---------|-------------------------------------|
| GPU Usage          | %       | NVML / `gpu_busy_percent`           |
| GPU Memory Used    | MB      | NVML / `mem_info_vram_used`         |
| GPU Memory Used    | %       | NVML / `mem_info_vram_used` + total |
| GPU Temperature    | °C      | NVML / `temp1_input`                |
| GPU Core Frequency | MHz     | NVML / `freq1_input`                |
| GPU Fan Speed      | % / RPM | NVML / `fan1_input`                 |
| GPU Power          | W       | NVML / `power1_average`             |

## Notes

- On Windows, GPU sensors from LHM (LibreHardwareMonitor) are correctly separated from CPU sensors by checking for `amdcpu`/`intelcpu` in the sensor identifier path before matching `amd`/`gpu`/`nvidia`.
- "GPU METRICS" category added to both the GUI selector and the CLI sensor list.
- If no GPU is found, the discovery step prints install instructions (`pip install nvidia-ml-py3`).
