### PR TITLE
Add swap memory monitoring (percentage and GB) support

### DIFF
--- a/pc_stats_monitor_v2_linux.py
+++ b/pc_stats_monitor_v2_linux.py
@@ -94,6 +94,28 @@ def discover_sensors():
     })
 
     sensor_database["system"].append({
+        "name": "SWAP",
+        "display_name": "Swap Usage",
+        "source": "psutil",
+        "type": "percent",
+        "unit": "%",
+        "psutil_method": "swap_memory.percent",
+        "custom_label": "",
+        "current_value": int(psutil.swap_memory().percent)
+    })
+
+    sensor_database["system"].append({
+        "name": "SWAP_GB",
+        "display_name": "Swap Used (GB)",
+        "source": "psutil",
+        "type": "memory",
+        "unit": "GB",
+        "psutil_method": "swap_memory.used",
+        "custom_label": "",
+        "current_value": int(psutil.swap_memory().used / (1024**3))
+    })
+
+    sensor_database["system"].append({
         "name": "DISK",
         "display_name": "Disk / Usage",
         "source": "psutil",
@@ -1355,6 +1377,10 @@ def get_metric_value(metric_config):
             return int(psutil.virtual_memory().percent)
         elif method == "virtual_memory.used":
             return int(psutil.virtual_memory().used / (1024**3))  # GB
+        elif method == "swap_memory.percent":
+            return int(psutil.swap_memory().percent)
+        elif method == "swap_memory.used":
+            return int(psutil.swap_memory().used / (1024**3))  # GB
         elif method == "disk_usage":
             return int(psutil.disk_usage('/').percent)
 


### PR DESCRIPTION
This PR adds two new system metrics for swap memory monitoring to the Linux PC stats monitor:

- **`SWAP`** — swap usage as a percentage (`%`)
- **`SWAP_GB`** — swap memory used in gigabytes (`GB`)

## Changes

### `pc_stats_monitor_v2_linux.py`

**Sensor discovery (`discover_sensors`):**
- Added `SWAP` sensor entry using `psutil.swap_memory().percent`
- Added `SWAP_GB` sensor entry using `psutil.swap_memory().used / (1024**3)`

**Metric value fetching (`get_metric_value`):**
- Added handling for `swap_memory.percent` psutil method → returns `int(%)`
- Added handling for `swap_memory.used` psutil method → returns `int(GB)`

## Usage

After this change, the following metric names become available in `monitor_config_linux.json`:

```json
{ "metric": "SWAP" }
{ "metric": "SWAP_GB" }
```

These can be used in any display widget that supports `system` category metrics, just like `RAM` and `RAM_GB`.

## Testing

- Verified sensor appears in `discover_sensors()` output
- Verified `get_metric_value()` returns correct integer values for both methods
